### PR TITLE
[WIP] Set UGI configuration after initializing hadoop configuration

### DIFF
--- a/src/main/scala/com/kakao/cuesheet/launcher/YarnConnector.scala
+++ b/src/main/scala/com/kakao/cuesheet/launcher/YarnConnector.scala
@@ -16,6 +16,7 @@ import com.kakao.mango.logging.Logging
 import com.kakao.mango.text.Resource
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
+import org.apache.hadoop.security.UserGroupInformation
 
 import scala.xml.XML
 
@@ -100,6 +101,8 @@ object YarnConnector extends Logging {
 
     // this runs nonexistent python scripts, causing error messages to flood the console
     conf.unset("net.topology.script.file.name")
+
+    UserGroupInformation.setConfiguration(conf)
 
     (conf, base)
   }


### PR DESCRIPTION
This was to solve the issue #1. It was tested with YARN cluster which requires Kerberos authentication. Submitting applications to this cluster failed while creating a new directory on HDFS since authentication method had not been set properly. After this modification, submission of the application became successful. However, failure of the authentication between cluster nodes remains the issue.